### PR TITLE
Dev

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,16 @@
 import { ShowcaseCounter } from '@/components/ShowcaseCounter'
+import { ShowcaseProfileForm } from './components/ShowcaseForm'
 
 const App = () => {
   return (
+    <>
+      <div className="min-h-screen flex items-center justify-center bg-neutral-100 dark:bg-neutral-900">
+        <ShowcaseCounter />
+      </div>
     <div className="min-h-screen flex items-center justify-center bg-neutral-100 dark:bg-neutral-900">
-      <ShowcaseCounter />
-    </div>
-    
+        <ShowcaseProfileForm />
+      </div>
+    </>
   )
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { ShowcaseCounter } from '@/components/ShowcaseCounter'
 import { ShowcaseProfileForm } from './components/ShowcaseForm'
+import { DevLogPanel } from './components/log/DevLogPanel'
 
 const App = () => {
   return (
@@ -10,6 +11,7 @@ const App = () => {
     <div className="min-h-screen flex items-center justify-center bg-neutral-100 dark:bg-neutral-900">
         <ShowcaseProfileForm />
       </div>
+      <DevLogPanel />
     </>
   )
 }

--- a/src/components/ShowcaseForm.tsx
+++ b/src/components/ShowcaseForm.tsx
@@ -1,0 +1,84 @@
+// components/ShowcaseProfileForm.tsx
+import { createForm } from '@/core/form/createForm'
+import { useReactiveDOM } from '@/core/hooks/useReactiveDOM'
+import { Input } from '@/components/ui/Input'
+import { Card } from '@/components/ui/Card'
+import { Title } from '@/components/ui/Title'
+import { Button } from '@/components/ui/Button'
+import { RenderCount } from '@/components/ui/RenderCount'
+import { useRef } from 'react'
+
+const profileForm = createForm({
+  fields: {
+    email: {
+      initial: '',
+      validate: (v) => v.includes('@') ? null : 'Missing @'
+    },
+    age: {
+      initial: 18,
+      validate: (v) => v < 18 ? 'Too young' : null
+    }
+  }
+})
+
+export const ShowcaseProfileForm = () => {
+  const emailRef = profileForm.email.ref
+  const ageRef = profileForm.age.ref
+  const emailErrorRef = useRef<HTMLParagraphElement>(null)
+  const ageErrorRef = useRef<HTMLParagraphElement>(null)
+  const validRef = useRef<HTMLParagraphElement>(null)
+
+  useReactiveDOM(emailRef, profileForm.email.value)
+  useReactiveDOM(ageRef, profileForm.age.value)
+  useReactiveDOM(emailErrorRef, profileForm.email.error)
+  useReactiveDOM(ageErrorRef, profileForm.age.error)
+  useReactiveDOM(validRef, profileForm.isValid)
+
+  return (
+    <Card size="md" variant="accent">
+      <div className="space-y-6">
+        <Title as="h2">📋 Profile Form (Reactive)</Title>
+        <RenderCount />
+
+        <Input
+          id="email"
+          label="Email"
+          value={profileForm.email.value.value}
+          onChange={(v) => profileForm.email.set(v)}
+          refValue={emailRef}
+          refError={emailErrorRef}
+        />
+
+        <Input
+          id="age"
+          label="Age"
+          type="number"
+          value={profileForm.age.value.value.toString()}
+          onChange={(v) => profileForm.age.set(parseInt(v))}
+          refValue={ageRef}
+          refError={ageErrorRef}
+        />
+
+        <p ref={validRef} className="text-gray-500" />
+
+        <div className="flex gap-2 pt-4">
+          <Button
+            onClick={() => {
+              profileForm.email.set('user@example.com')
+              profileForm.age.set(25)
+            }}
+          >
+            Autofill
+          </Button>
+
+          <Button variant="secondary" onClick={() => {
+            profileForm.email.set('')
+            profileForm.age.set(18)
+          }}>
+            Reset
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/log/DevLogPanel.tsx
+++ b/src/components/log/DevLogPanel.tsx
@@ -1,0 +1,25 @@
+import { devLogTree } from '@/core/dev/logger/logTree'
+
+export const DevLogPanel = () => {
+  return (
+    <div className="p-4 text-sm bg-gray-500 text-white overflow-auto max-h-[80vh] rounded shadow-xl">
+      {[...devLogTree.entries()].map(([source, group]) => (
+        <div key={source}>
+          <h2 className="font-bold text-yellow-400">{source}</h2>
+          {Object.entries(group.signals).map(([signalId, events]) => (
+            <details key={signalId} className="ml-4 mb-2">
+              <summary className="text-blue-300">{signalId}</summary>
+              <ul className="ml-4">
+                {events.map((e, idx) => (
+                  <li key={idx} className="text-gray-300">
+                    {e.type} {e.payload !== undefined && `→ ${JSON.stringify(e.payload)}`}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -7,11 +7,13 @@ type InputProps = {
   value: string
   onChange: (val: string) => void
   error?: string
-  type?: 'text' | 'email' | 'password'
+  type?: 'text' | 'email' | 'password' | 'number'
   onBlur?: () => void
   onFocus?: () => void
   autoComplete?: string
   autoFocus?: boolean
+  refValue?: React.RefObject<HTMLInputElement>
+  refError?: React.RefObject<HTMLParagraphElement | null>
 }
 
 export const Input: React.FC<InputProps> = ({
@@ -25,12 +27,14 @@ export const Input: React.FC<InputProps> = ({
   onFocus,
   autoComplete = 'off',
   autoFocus = false,
+  refValue,
+  refError
 }) => {
   const [isFocused, setIsFocused] = useState(false)
   const shouldFloat = isFocused || value.length > 0
 
   return (
-    <div className="mb-4 relative">
+    <div className="mb-4 relative bg-neutral-100 dark:bg-neutral-900">
       <input
         id={id}
         type={type}
@@ -44,10 +48,11 @@ export const Input: React.FC<InputProps> = ({
           setIsFocused(false)
           onBlur?.()
         }}
+        ref={refValue}
         aria-invalid={!!error}
         aria-describedby={error ? `${id}-error` : undefined}
         className={clsx(
-          'peer w-full px-3 pt-6 pb-2 text-sm border rounded-md shadow-sm focus:outline-none transition-all',
+          'peer w-full px-3 pt-6 pb-2 text-sm border rounded-md shadow-sm focus:outline-none transition-all text-neutral-900',
           error
             ? 'border-red-500 focus:border-red-500'
             : 'border-gray-300 focus:border-blue-500'
@@ -66,6 +71,7 @@ export const Input: React.FC<InputProps> = ({
         {label}
       </label>
       <p
+        ref={refError}
         id={`${id}-error`}
         className={clsx('text-sm mt-1', error ? 'text-red-500' : 'invisible h-5')}
       >

--- a/src/core/dev/logger/context.ts
+++ b/src/core/dev/logger/context.ts
@@ -1,0 +1,13 @@
+let currentSource: { name: string; instance?: string } | null = null
+
+export const withSource = <T>(source: string, fn: () => T, instance?: string): T => {
+  const prev = currentSource
+  currentSource = { name: source, instance }
+  const result = fn()
+  currentSource = prev
+  return result
+}
+
+export const getCurrentSource = (): { name: string; instance?: string } | null => {
+  return currentSource
+}

--- a/src/core/dev/logger/eventBus.ts
+++ b/src/core/dev/logger/eventBus.ts
@@ -1,0 +1,82 @@
+// core/devtools/eventBus.ts
+
+export type EventPayload = {
+  context?: string | null
+  source?: string | null
+  error?: Error | null
+  message?: string | null
+  level?: 'info' | 'warn' | 'error'
+  [key: string]: any
+}
+
+export type EventHandler<T extends EventPayload = EventPayload> = (type: string, payload: T) => void
+
+const listeners: Record<string, EventHandler[]> = {}
+
+export const emit = <T extends EventPayload = EventPayload>(type: string, payload: T): void => {
+  const specific = listeners[type] || []
+  const wildcard = listeners['*'] || []
+
+  for (const fn of specific) {
+    fn(type, payload)
+  }
+
+  for (const fn of wildcard) {
+    fn(type, payload)
+  }
+}
+
+export const on = <T extends EventPayload = EventPayload>(type: string, handler: EventHandler<T>): void => {
+  if (!listeners[type]) {
+    listeners[type] = []
+  }
+
+  listeners[type].push(handler as EventHandler<EventPayload>)
+}
+
+export const clearListeners = (type?: string): void => {
+  if (type) {
+    delete listeners[type]
+  } else {
+    for (const key in listeners) {
+      delete listeners[key]
+    }
+  }
+}
+
+export const emitError = (context: string, error: Error, extra?: Record<string, any>): void => {
+  emit(`error:${context}`, {
+    context,
+    error,
+    level: 'error',
+    ...extra
+  })
+}
+
+export const emitWarn = (context: string, message: string, extra?: Record<string, any>): void => {
+  emit(`warn:${context}`, {
+    context,
+    message,
+    level: 'warn',
+    ...extra
+  })
+}
+
+export const emitInfo = (context: string, message: string, extra?: Record<string, any>): void => {
+  emit(`info:${context}`, {
+    context,
+    message,
+    level: 'info',
+    ...extra
+  })
+}
+
+if (import.meta.env.DEV) {
+  on('*', (type, payload) => {
+    console.debug(
+      `%c[${type}]`,
+      'color: #888; font-weight: bold',
+      payload
+    )
+  })
+}

--- a/src/core/dev/logger/eventBus.ts
+++ b/src/core/dev/logger/eventBus.ts
@@ -1,4 +1,4 @@
-// core/devtools/eventBus.ts
+import { recordSignalLog } from "./logTree"
 
 export type EventPayload = {
   context?: string | null
@@ -73,6 +73,10 @@ export const emitInfo = (context: string, message: string, extra?: Record<string
 
 if (import.meta.env.DEV) {
   on('*', (type, payload) => {
+    if (type.startsWith('signal:')) {
+      recordSignalLog(type, payload)
+    }
+
     console.debug(
       `%c[${type}]`,
       'color: #888; font-weight: bold',

--- a/src/core/dev/logger/logTree.ts
+++ b/src/core/dev/logger/logTree.ts
@@ -1,0 +1,60 @@
+type SignalEvent = {
+  id: string
+  name: string
+  type: string
+  timestamp: number
+  payload?: any
+}
+
+type SignalGroup = {
+  source: string
+  signals: Record<string, SignalEvent[]>
+}
+
+const devLogTree = new Map<string, SignalGroup>()
+
+export function recordSignalLog(type: string, payload: any) {
+  if (!payload?.id || !payload?.name) return
+
+  const groupKey = payload.source ?? 'unknown'
+  if (!devLogTree.has(groupKey)) {
+    devLogTree.set(groupKey, { source: groupKey, signals: {} })
+  }
+
+  const group = devLogTree.get(groupKey)!
+  if (!group.signals[payload.id]) {
+    group.signals[payload.id] = []
+  }
+
+  group.signals[payload.id].push({
+    id: payload.id,
+    name: payload.name,
+    type,
+    timestamp: payload.timestamp,
+    payload
+  })
+}
+
+export function printDevLogTree() {
+  for (const [source, group] of devLogTree.entries()) {
+    console.groupCollapsed(`📦 Source: %c${source}`, 'color: goldenrod; font-weight: bold')
+
+    for (const [id, events] of Object.entries(group.signals)) {
+      const label = `${id} (${events[0]?.name})`
+
+      console.groupCollapsed(`🧠 Signal: %c${label}`, 'color: steelblue; font-weight: bold')
+      console.table(events.map(e => ({
+        type: e.type,
+        time: new Date(e.timestamp).toLocaleTimeString(),
+        ...e.payload
+      })))
+      console.groupEnd()
+    }
+
+    console.groupEnd()
+  }
+}
+
+if (import.meta.env.DEV) {
+  ;(window as any).printDevLogTree = printDevLogTree
+}

--- a/src/core/dev/logger/logTree.ts
+++ b/src/core/dev/logger/logTree.ts
@@ -58,3 +58,5 @@ export function printDevLogTree() {
 if (import.meta.env.DEV) {
   ;(window as any).printDevLogTree = printDevLogTree
 }
+
+export { devLogTree }

--- a/src/core/dev/logger/logger.ts
+++ b/src/core/dev/logger/logger.ts
@@ -1,0 +1,51 @@
+import { getCurrentSource } from './context'
+
+export type LogLevel = 'init' | 'get' | 'set' | 'sub' | 'effect' | 'unsub'
+
+const IS_ENABLED: boolean =
+  import.meta.env.VITE_DEBUG_SIGNAL === 'true' ||
+  import.meta.env.MODE === 'development'
+
+export function logSignal(label: string, type: LogLevel, payload?: unknown): void {
+  if (!IS_ENABLED) return
+
+  const emoji =
+    type === 'get' ? '👁️ GET'
+    : type === 'set' ? '✏️ SET'
+    : type === 'init' ? '🧠 INIT'
+    : type === 'sub' ? '📡 SUB'
+    : type === 'unsub' ? '🚫 UNSUB'
+    : type === 'effect' ? '✨ EFFECT'
+    : '❓'
+
+  const color =
+    type === 'get' ? 'dodgerblue'
+    : type === 'set' ? 'green'
+    : type === 'init' ? '#999'
+    : type === 'sub' ? 'goldenrod'
+    : type === 'unsub' ? 'crimson'
+    : '#333'
+
+  const source = getCurrentSource()
+
+  const groupLabel = source
+    ? `[${source.name}${source.instance ? ':' + source.instance : ''}]`
+    : '[signal]'
+
+  // Outer group: by source
+  console.groupCollapsed(`%c${groupLabel}`, 'color: #aaa; font-weight: bold')
+
+  // Inner group: by signal label and action
+  console.groupCollapsed(
+    `%c[${label}] %c${emoji}`,
+    'color:#888;font-weight:bold',
+    `color:${color};font-weight:bold`
+  )
+
+  if (payload !== undefined) {
+    console.log('%cPayload:', 'color:#999', payload)
+  }
+
+  console.groupEnd()
+  console.groupEnd()
+}

--- a/src/core/form/createForm.ts
+++ b/src/core/form/createForm.ts
@@ -62,5 +62,5 @@ export const createForm = <TFields extends Record<string, FieldConfig<any>>>(con
       ...fields,
       isValid
     }
-  })
+  }, 'yo')
 }

--- a/src/core/form/createForm.ts
+++ b/src/core/form/createForm.ts
@@ -1,0 +1,66 @@
+import { createSignalObject } from '../signal/createSignalObject'
+import { computed } from '../signal/computed'
+import { effect } from '../signal/createSignal'
+import { withSource } from '../dev/logger/context'
+
+export type FieldConfig<T = string> = {
+  initial: T
+  validate?: (value: T) => string | null
+}
+
+export type Field<T> = {
+  value: ReturnType<typeof createSignalObject<T>>
+  error: ReturnType<typeof createSignalObject<string | null>>
+  touched: ReturnType<typeof createSignalObject<boolean>>
+  ref: React.RefObject<HTMLInputElement>
+  set: (val: T) => void
+}
+
+export const createForm = <TFields extends Record<string, FieldConfig<any>>>(config: {
+  fields: TFields
+}) => {
+  return withSource('createForm', () => {
+  const fields = {} as {
+    [K in keyof TFields]: Field<TFields[K]['initial']>
+  }
+
+  for (const key in config.fields) {
+    const fieldConfig = config.fields[key]
+    const value = createSignalObject(fieldConfig.initial)
+    const error = createSignalObject<string | null>(null)
+    const touched = createSignalObject(false)
+    const ref = { current: null } as unknown as React.RefObject<HTMLInputElement>
+
+    const set = (val: any) => {
+      value.set(val)
+      touched.set(true)
+      if (fieldConfig.validate) {
+        error.set(fieldConfig.validate(val))
+      }
+    }
+
+    fields[key] = {
+      value,
+      error,
+      touched,
+      ref,
+      set
+    } as any
+  }
+
+  const rawIsValid = computed(() => {
+    return Object.values(fields).every(field => field.error.value === null)
+  })
+  
+  const isValid = createSignalObject(rawIsValid())
+  
+  effect(() => {
+    isValid.set(rawIsValid())
+  })
+
+  return {
+      ...fields,
+      isValid
+    }
+  })
+}

--- a/src/core/hooks/useReactiveDOM.ts
+++ b/src/core/hooks/useReactiveDOM.ts
@@ -1,14 +1,19 @@
 import { useEffect } from 'react'
 import { effect } from '../signal/createSignal'
 
-export function useReactiveDOM<T>(
-  ref: React.RefObject<HTMLElement | null>,
-  signal: { value: T }
-) {
+export const useReactiveDOM = <T extends HTMLElement>(
+  ref: React.RefObject<T>,
+  signal: { value: any }
+) => {
   useEffect(() => {
     return effect(() => {
       if (ref.current) {
-        ref.current.textContent = String(signal.value)
+        // автоматическая реакция в зависимости от элемента
+        if ('value' in ref.current) {
+          (ref.current as any).value = signal.value
+        } else {
+          ref.current.textContent = String(signal.value ?? '')
+        }
       }
     })
   }, [ref])

--- a/src/core/hooks/useStore.ts
+++ b/src/core/hooks/useStore.ts
@@ -1,0 +1,28 @@
+import { useSignalValue } from '../hooks/useSignalValue'
+
+export const useStore = <
+  TInput extends Record<string, { set: (...args: any[]) => void }>,
+  TOutput extends Record<string, any>
+>(slice: {
+  input: TInput
+  output: TOutput
+}) => {
+  return () => {
+    const outputMapped = Object.entries(slice.output).reduce((acc, [key, signal]) => {
+      if ('value' in signal) {
+        acc[key as keyof TOutput] = useSignalValue(signal)
+      }
+      return acc
+    }, {} as { [K in keyof TOutput]: TOutput[K]['value'] })
+
+    const inputMapped = Object.entries(slice.input).reduce((acc, [key, signal]) => {
+      acc[key as keyof TInput] = (...args: any[]) => signal.set(args)
+      return acc
+    }, {} as { [K in keyof TInput]: (...args: any[]) => void })
+
+    return {
+      ...outputMapped,
+      ...inputMapped
+    }
+  }
+}

--- a/src/core/module/createModule.ts
+++ b/src/core/module/createModule.ts
@@ -1,0 +1,11 @@
+export function createModule<
+  I extends Record<string, any>,
+  O extends Record<string, any>
+>({ input, output, setup }: {
+  input: I
+  output: O
+  setup: (ctx: { input: I; output: O }) => void
+}) {
+  setup({ input, output })
+  return { input, output }
+}

--- a/src/core/signal/computed.ts
+++ b/src/core/signal/computed.ts
@@ -1,0 +1,11 @@
+import { createSignal, effect } from './createSignal'
+
+export function computed<T>(fn: () => T) {
+  const [get, set] = createSignal(fn())
+
+  effect(() => {
+    set(fn())
+  })
+
+  return get
+}

--- a/src/core/signal/createSignal.ts
+++ b/src/core/signal/createSignal.ts
@@ -1,22 +1,46 @@
+import { logSignal } from "../dev/logger/logger"
+
 type Effect = () => void
 
 let currentEffect: Effect | null = null
+let signalId = 0
 
-export function createSignal<T>(initial: T): [() => T, (v: T | ((prev: T) => T)) => void] {
+export function createSignal<T>(
+  initial: T,
+  label?: string
+): [() => T, (v: T | ((prev: T) => T)) => void, (fn: () => void) => () => void] {
   let value = initial
   const subscribers = new Set<Effect>()
+  const debugLabel = label ?? `signal-${signalId++}`
+
+  logSignal(debugLabel, 'init', value)
 
   const get = () => {
-    if (currentEffect) subscribers.add(currentEffect)
+    logSignal(debugLabel, 'get', value)
+    if (currentEffect) {
+      subscribers.add(currentEffect)
+      logSignal(debugLabel, 'sub', currentEffect.name || 'anonymous effect')
+    }
     return value
   }
 
   const set = (next: T | ((prev: T) => T)) => {
+    const old = value
     value = typeof next === 'function' ? (next as (prev: T) => T)(value) : next
+    logSignal(debugLabel, 'set', { from: old, to: value })
     subscribers.forEach(fn => fn())
   }
 
-  return [get, set]
+  const subscribe = (fn: () => void) => {
+    subscribers.add(fn)
+    logSignal(debugLabel, 'sub', fn.name || 'anonymous')
+    return () => {
+      subscribers.delete(fn)
+      logSignal(debugLabel, 'unsub', fn.name || 'anonymous')
+    }
+  }
+
+  return [get, set, subscribe]
 }
 
 export function effect(fn: Effect) {

--- a/src/core/signal/createSignal.ts
+++ b/src/core/signal/createSignal.ts
@@ -1,7 +1,7 @@
 import { emit } from '../dev/logger/eventBus'
 import { getCurrentSource } from '../dev/logger/context'
 
-type Effect = () => void
+export type Effect = () => void
 
 let currentEffect: Effect | null = null
 let signalId = 0
@@ -12,37 +12,80 @@ export function createSignal<T>(
 ): [() => T, (v: T | ((prev: T) => T)) => void, (fn: () => void) => () => void] {
   let value = initial
   const subscribers = new Set<Effect>()
-  const signal = label ?? `signal-${signalId++}`
-  const source = getCurrentSource()
+  const id = `signal-${signalId++}`
+  const name = label ?? id
+  const sourceObj = getCurrentSource()
+  const source = sourceObj
+    ? `${sourceObj.name}${sourceObj.instance ? ':' + sourceObj.instance : ''}`
+    : undefined
 
-  emit('signal:init', { signal, value, source })
+  emit('signal:init', {
+    id,
+    name,
+    value,
+    source,
+    timestamp: Date.now()
+  })
 
   const get = () => {
-    emit('signal:get', { signal, value, source })
+    emit('signal:get', {
+      id,
+      name,
+      value,
+      source,
+      timestamp: Date.now()
+    })
+
     if (currentEffect) {
       subscribers.add(currentEffect)
       emit('signal:sub', {
-        signal,
+        id,
+        name,
         effect: currentEffect.name || 'anonymous',
-        source
+        source,
+        timestamp: Date.now()
       })
     }
+
     return value
   }
 
   const set = (next: T | ((prev: T) => T)) => {
     const from = value
     value = typeof next === 'function' ? (next as (prev: T) => T)(value) : next
-    emit('signal:set', { signal, from, to: value, source })
-    for (const fn of subscribers) fn()
+
+    emit('signal:set', {
+      id,
+      name,
+      from,
+      to: value,
+      source,
+      timestamp: Date.now()
+    })
+
+    for (const fn of subscribers) {
+      fn()
+    }
   }
 
   const subscribe = (fn: () => void) => {
     subscribers.add(fn)
-    emit('signal:sub', { signal, effect: fn.name || 'anonymous', source })
+    emit('signal:sub', {
+      id,
+      name,
+      effect: fn.name || 'anonymous',
+      source,
+      timestamp: Date.now()
+    })
     return () => {
       subscribers.delete(fn)
-      emit('signal:unsub', { signal, effect: fn.name || 'anonymous', source })
+      emit('signal:unsub', {
+        id,
+        name,
+        effect: fn.name || 'anonymous',
+        source,
+        timestamp: Date.now()
+      })
     }
   }
 

--- a/src/core/signal/createSignalObject.ts
+++ b/src/core/signal/createSignalObject.ts
@@ -1,13 +1,14 @@
 import { createSignal } from './createSignal'
 
-export function createSignalObject<T>(initial: T) {
-  const [get, set] = createSignal(initial)
+export const createSignalObject = <T>(initial: T) => {
+  const [get, set, subscribe] = createSignal(initial)
 
   return {
     get value() {
       return get()
     },
     set: set,
-    update: (fn: (prev: T) => T) => set(fn)
+    update: (fn: (prev: T) => T) => set(fn),
+    subscribe
   }
 }

--- a/src/store/formSlice.ts
+++ b/src/store/formSlice.ts
@@ -1,23 +1,16 @@
 import { defineSlice } from '@/core/store/defineSlice'
 
-interface FormState {
-  name: string,
-  email: string
-}
-
-const initial = {
-  name: '',
-  email: ''
-}
-
-export const form = defineSlice<FormState>({
-  initial,
-  reducers: {
-    setName: (state, value: string) => {
-      state.name = value
+export const form = defineSlice({
+  state: {
+    name: '',
+    email: ''
+  },
+  actions: {
+    setName: (state, val: string) => {
+      state.name = val
     },
-    setEmail: (state, value: string) => {
-      state.email = value
+    setEmail: (state, val: string) => {
+      state.email = val
     }
   },
   selectors: {

--- a/src/store/hooks/useForm.ts
+++ b/src/store/hooks/useForm.ts
@@ -1,0 +1,4 @@
+import { form } from '@/store/formSlice'
+import { useStore } from '@/core/hooks/useStore'
+
+export const useForm = useStore(form)


### PR DESCRIPTION
✅ Dev Logging Infrastructure – Step 1

This PR introduces the foundation for a signal-based developer logging system:
	•	➕ Introduced eventBus and logTree modules for event tracking
	•	🧠 Signals now emit structured events on init, get, set, sub, unsub
	•	🌲 Signals are grouped by source/module into a nested dev log tree (devLogTree)
	•	📊 Added printDevLogTree() for inspecting logs in a collapsible, tabular format
	•	🔗 Connected signal creation to withSource context
	•	🧪 Logs include id, name, source, value, from → to, timestamp, effect

This is the first milestone toward a developer-friendly debug panel for tracking reactive state and signal flows.

⸻

🔄 Next steps (future PRs):
	•	Add DevLogPanel component to view log tree in-browser
	•	Improve log readability and filtering (e.g. by type or signal)
	•	Connect eventBus live updates to the panel

Let me know if you’d like this expanded or translated!